### PR TITLE
Remove faker from BookingTests

### DIFF
--- a/tests/DomainTests/BookingTests.cs
+++ b/tests/DomainTests/BookingTests.cs
@@ -1,6 +1,4 @@
-﻿using Bogus;
-using ReserveSpot;
-using Sprache;
+﻿using ReserveSpot;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
 
@@ -9,13 +7,11 @@ namespace DomainTests
     [TestClass]
     public class BookingTests
     {
-        public Faker faker = new Faker("en");
-
         [TestMethod]
         public void Constructor_InitializesProperties()
         {
-            DateTime startDate = faker.Date.Soon();
-            DateTime endDate = faker.Date.Soon(7);
+            DateTime startDate = new DateTime(2024, 4, 7);
+            DateTime endDate = new DateTime(2024, 4, 14);
             Guid userId = Guid.NewGuid();
             Guid propertyId = Guid.NewGuid();
 
@@ -29,18 +25,39 @@ namespace DomainTests
         }
 
         [TestMethod]
-        public void ValidateObject_InvalidBooking()
+        public void ValidateObject_ValidBooking()
         {
-            var faker = new Faker();
-            DateTime startDate = faker.Date.Soon(2);
-            DateTime endDate = faker.Date.Soon();
+            DateTime startDate = new DateTime(2024, 4, 7);
+            DateTime endDate = new DateTime(2024, 4, 14);
             Guid userId = Guid.NewGuid();
             Guid propertyId = Guid.NewGuid();
-          
+
             Booking booking = new Booking(startDate, endDate, userId, propertyId);
 
-            var context = new ValidationContext(booking, serviceProvider: null, items: null);
-            var results = new List<System.ComponentModel.DataAnnotations.ValidationResult>();
+            var context = new ValidationContext(booking);
+            var results = new List<ValidationResult>();
+            var isValid = Validator.TryValidateObject(booking, context, results, true);
+
+            Assert.IsTrue(isValid);
+
+            foreach (var result in results)
+            {
+                Debug.WriteLine(result.ErrorMessage);
+            }
+        }
+
+        [TestMethod]
+        public void ValidateObject_InvalidBooking()
+        {
+            DateTime startDate = new DateTime(2024, 4, 9);
+            DateTime endDate = new DateTime(2024, 4, 7);
+            Guid userId = Guid.NewGuid();
+            Guid propertyId = Guid.NewGuid();
+
+            Booking booking = new Booking(startDate, endDate, userId, propertyId);
+
+            var context = new ValidationContext(booking);
+            var results = new List<ValidationResult>();
             var isValid = Validator.TryValidateObject(booking, context, results, true);
 
             Assert.IsFalse(isValid);
@@ -63,44 +80,81 @@ namespace DomainTests
         [TestMethod]
         public void Edit_UpdatesBookingDates_Valid()
         {
-            DateTime startDate = faker.Date.Soon();
-            DateTime endDate = faker.Date.Soon(7);
+            DateTime startDate = new DateTime(2024, 4, 7);
+            DateTime endDate = new DateTime(2024, 4, 14);
             Guid userId = Guid.NewGuid();
             Guid propertyId = Guid.NewGuid();
             Booking booking = new Booking(startDate, endDate, userId, propertyId);
-            DateTime newStartDate = faker.Date.Soon(3);
-            DateTime newEndDate = faker.Date.Soon(10);
+            DateTime newStartDate = new DateTime(2024, 4, 10);
+            DateTime newEndDate = new DateTime(2024, 4, 17);
 
             booking.Edit(newStartDate, newEndDate);
-                     
-            var context = new ValidationContext(booking, serviceProvider: null, items: null);
-            var results = new List<System.ComponentModel.DataAnnotations.ValidationResult>();
+            var context = new ValidationContext(booking);
+            var results = new List<ValidationResult>();
             var isValid = Validator.TryValidateObject(booking, context, results, true);
 
-                    
             Assert.IsTrue(isValid);
-            Assert.IsTrue(results.Count == 0);          
+            Assert.IsTrue(results.Count == 0);
         }
 
         [TestMethod]
         public void Edit_UpdatesBookingDates_Invalid()
         {
-            DateTime startDate = faker.Date.Soon();
-            DateTime endDate = faker.Date.Soon(7);
+            DateTime startDate = new DateTime(2024, 4, 7);
+            DateTime endDate = new DateTime(2024, 4, 14);
             Guid userId = Guid.NewGuid();
             Guid propertyId = Guid.NewGuid();
             Booking booking = new Booking(startDate, endDate, userId, propertyId);
 
-            DateTime newStartDate = faker.Date.Soon(10);
-            DateTime newEndDate = faker.Date.Soon();
+            DateTime newStartDate = new DateTime(2024, 4, 17);
+            DateTime newEndDate = new DateTime(2024, 4, 10);
 
             booking.Edit(newStartDate, newEndDate);
-                     
-            var context = new ValidationContext(booking, serviceProvider: null, items: null);
-            var results = new List<System.ComponentModel.DataAnnotations.ValidationResult>();
+
+            var context = new ValidationContext(booking);
+            var results = new List<ValidationResult>();
             var isValid = Validator.TryValidateObject(booking, context, results, true);
 
             Assert.IsFalse(isValid);
+        }
+
+        [TestMethod]
+        public void Edit_WhenStatusIsFinished_ThrowsException()
+        {
+            DateTime startDate = DateTime.Now.AddDays(-5);
+            DateTime endDate = DateTime.Now.AddDays(-3);
+            Guid userId = Guid.NewGuid();
+            Guid propertyId = Guid.NewGuid();
+            Booking booking = new Booking(startDate, endDate, userId, propertyId);
+            booking.CheckBookingStatus();
+
+            Assert.ThrowsException<InvalidOperationException>(() =>
+            {
+                try
+                {
+                    booking.Edit(DateTime.Now.AddDays(1), DateTime.Now.AddDays(3));
+                }
+                catch (InvalidOperationException ex)
+                {
+                    Assert.AreEqual("Cannot edit a finished booking", ex.Message);
+                    throw;
+                }
+            });
+        }
+
+        [TestMethod]
+        public void Edit_WhenStatusIsNotFinished_UpdatesDates()
+        {
+            DateTime startDate = DateTime.Now.AddDays(-5);
+            DateTime endDate = DateTime.Now.AddDays(-3);
+            Guid userId = Guid.NewGuid();
+            Guid propertyId = Guid.NewGuid();
+            Booking booking = new Booking(startDate, endDate, userId, propertyId);
+
+            booking.Edit(DateTime.Now.AddDays(1), DateTime.Now.AddDays(3));
+
+            Assert.AreEqual(DateTime.Now.AddDays(1).Date, booking.StartDate.Date);
+            Assert.AreEqual(DateTime.Now.AddDays(3).Date, booking.EndDate.Date);
         }
     }
 }


### PR DESCRIPTION
Removed `faker` from `BookingTests` due to unexpected inconsistent generation of test data.